### PR TITLE
Added BUILD_TESTS option

### DIFF
--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -19,22 +19,27 @@ cmake_minimum_required(VERSION 3.16)
 
 project(tasecureapi)
 
-# Download and unpack googletest at configure time
-include(FetchContent)
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
-)
+option(BUILD_TESTS "Builds and installs the unit tests" ON)
+option(BUILD_DOC   "Build documentation" ON)
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+if(${BUILD_TESTS})
+    # Download and unpack googletest at configure time
+    include(FetchContent)
+    FetchContent_Declare(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.13.0
+    )
+
+    FetchContent_GetProperties(googletest)
+    if(NOT googletest_POPULATED)
+        FetchContent_Populate(googletest)
+        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
+
+    set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
+    include(CTest)
+    include(GoogleTest)
 endif()
-
-set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
-include(CTest)
-include(GoogleTest)
 
 add_subdirectory(src)

--- a/reference/src/CMakeLists.txt
+++ b/reference/src/CMakeLists.txt
@@ -50,10 +50,19 @@ add_subdirectory(taimpl)
 add_subdirectory(util)
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).
-install(TARGETS saclient saclienttest taimpltest utiltest EXPORT sa-client-config
+include(GNUInstallDirs)
+install(TARGETS saclient EXPORT sa-client-config
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
         )
 
 install(DIRECTORY client/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if (BUILD_TESTS)
+    install(TARGETS saclienttest taimpltest utiltest
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+            RUNTIME DESTINATION bin
+            )
+endif ()

--- a/reference/src/client/CMakeLists.txt
+++ b/reference/src/client/CMakeLists.txt
@@ -126,210 +126,211 @@ endif ()
 
 target_clangformat_setup(saclient)
 
-# Google test
-add_executable(saclienttest
-        test/client_test_helpers.cpp
-        test/client_test_helpers.h
-        test/environment.cpp
-        test/sa_client_thread_test.cpp
-        test/sa_crypto_cipher_common.h
-        test/sa_crypto_cipher_common.cpp
-        test/sa_crypto_cipher_init.cpp
-        test/sa_crypto_cipher_init_aes_cbc.cpp
-        test/sa_crypto_cipher_init_aes_cbc_pkcs7.cpp
-        test/sa_crypto_cipher_init_aes_ctr.cpp
-        test/sa_crypto_cipher_init_aes_ecb.cpp
-        test/sa_crypto_cipher_init_aes_ecb_pkcs7.cpp
-        test/sa_crypto_cipher_init_aes_gcm.cpp
-        test/sa_crypto_cipher_init_ec_elgamal.cpp
-        test/sa_crypto_cipher_init_chacha20.cpp
-        test/sa_crypto_cipher_init_chacha20_poly1305.cpp
-        test/sa_crypto_cipher_init_rsa_oaep.cpp
-        test/sa_crypto_cipher_init_rsa_pkcs1v15.cpp
-        test/sa_crypto_cipher_process.cpp
-        test/sa_crypto_cipher_process_aes_cbc.cpp
-        test/sa_crypto_cipher_process_aes_cbc_pkcs7.cpp
-        test/sa_crypto_cipher_process_aes_ctr.cpp
-        test/sa_crypto_cipher_process_aes_ecb.cpp
-        test/sa_crypto_cipher_process_aes_ecb_pkcs7.cpp
-        test/sa_crypto_cipher_process_aes_gcm.cpp
-        test/sa_crypto_cipher_process_chacha20.cpp
-        test/sa_crypto_cipher_process_chacha20_poly1305.cpp
-        test/sa_crypto_cipher_process_ec_elgamal.cpp
-        test/sa_crypto_cipher_process_last.cpp
-        test/sa_crypto_cipher_process_last_aes_cbc.cpp
-        test/sa_crypto_cipher_process_last_aes_cbc_pkcs7.cpp
-        test/sa_crypto_cipher_process_last_aes_ctr.cpp
-        test/sa_crypto_cipher_process_last_aes_ecb.cpp
-        test/sa_crypto_cipher_process_last_aes_ecb_pkcs7.cpp
-        test/sa_crypto_cipher_process_last_aes_gcm.cpp
-        test/sa_crypto_cipher_process_last_chacha20_poly1305.cpp
-        test/sa_crypto_cipher_process_last_ec_elgamal.cpp
-        test/sa_crypto_cipher_process_last_rsa_oaep.cpp
-        test/sa_crypto_cipher_process_last_rsa_pkcs1v15.cpp
-        test/sa_crypto_cipher_process_rsa_oaep.cpp
-        test/sa_crypto_cipher_process_rsa_pkcs1v15.cpp
-        test/sa_crypto_cipher_release.cpp
-        test/sa_crypto_cipher_update_iv.cpp
-        test/sa_crypto_cipher_update_iv_aes_cbc.cpp
-        test/sa_crypto_cipher_update_iv_aes_cbc_pkcs7.cpp
-        test/sa_crypto_cipher_update_iv_aes_ctr.cpp
-        test/sa_crypto_cipher_update_iv_aes_ecb.cpp
-        test/sa_crypto_cipher_update_iv_aes_ecb_pkcs7.cpp
-        test/sa_crypto_cipher_update_iv_aes_gcm.cpp
-        test/sa_crypto_cipher_update_iv_chacha20.cpp
-        test/sa_crypto_cipher_update_iv_chacha20_poly1305.cpp
-        test/sa_crypto_cipher_update_iv_ec_elgamal.cpp
-        test/sa_crypto_cipher_update_iv_rsa_oaep.cpp
-        test/sa_crypto_cipher_update_iv_rsa_pkcs1v15.cpp
-        test/sa_crypto_mac_common.cpp
-        test/sa_crypto_mac_common.h
-        test/sa_crypto_mac_compute.cpp
-        test/sa_crypto_mac_init.cpp
-        test/sa_crypto_mac_process.cpp
-        test/sa_crypto_mac_process_key.cpp
-        test/sa_crypto_mac_release.cpp
-        test/sa_crypto_random.cpp
-        test/sa_crypto_sign.cpp
-        test/sa_crypto_sign_common.cpp
-        test/sa_crypto_sign_common.h
-        test/sa_crypto_sign_ec_ecdsa.cpp
-        test/sa_crypto_sign_ec_eddsa.cpp
-        test/sa_crypto_sign_rsa_pkcs1v15.cpp
-        test/sa_crypto_sign_rsa_pss.cpp
-        test/sa_engine_cipher.cpp
-        test/sa_engine_common.cpp
-        test/sa_engine_common.h
-        test/sa_engine_pkcs7.cpp
-        test/sa_engine_pkey_decrypt.cpp
-        test/sa_engine_pkey_derive.cpp
-        test/sa_engine_pkey_mac.cpp
-        test/sa_engine_pkey_sign.cpp
-        test/sa_get_device_id.cpp
-        test/sa_get_name.cpp
-        test/sa_get_ta_uuid.cpp
-        test/sa_get_version.cpp
-        test/sa_key_common.cpp
-        test/sa_key_common.h
-        test/sa_key_derive.cpp
-        test/sa_key_derive_ansi_x963.cpp
-        test/sa_key_derive_cmac.cpp
-        test/sa_key_derive_common.cpp
-        test/sa_key_derive_common.h
-        test/sa_key_derive_concat.cpp
-        test/sa_key_derive_hkdf.cpp
-        test/sa_key_derive_netflix.cpp
-        test/sa_key_derive_common_root_key_ladder.cpp
-        test/sa_key_derive_root_key_ladder.cpp
-        test/sa_key_digest.cpp
-        test/sa_key_exchange.cpp
-        test/sa_key_exchange_common.cpp
-        test/sa_key_exchange_common.h
-        test/sa_key_exchange_dh.cpp
-        test/sa_key_exchange_ecdh.cpp
-        test/sa_key_exchange_netflix.cpp
-        test/sa_key_export.cpp
-        test/sa_key_generate.cpp
-        test/sa_key_generate_dh.cpp
-        test/sa_key_generate_ec.cpp
-        test/sa_key_generate_rsa.cpp
-        test/sa_key_generate_symmetric.cpp
-        test/sa_key_get_public.cpp
-        test/sa_key_get_public_dh.cpp
-        test/sa_key_get_public_ec.cpp
-        test/sa_key_get_public_rsa.cpp
-        test/sa_key_get_public_symmetric.cpp
-        test/sa_key_header.cpp
-        test/sa_key_import.cpp
-        test/sa_key_import_common.cpp
-        test/sa_key_import_common.h
-        test/sa_key_import_ec_private_bytes.cpp
-        test/sa_key_import_exported.cpp
-        test/sa_key_import_rsa_private_key_info.cpp
-        test/sa_key_import_soc.cpp
-        test/sa_key_import_symmetric_bytes.cpp
-        test/sa_key_import_typej.cpp
-        test/sa_key_release.cpp
-        test/sa_key_unwrap.cpp
-        test/sa_key_unwrap_common.cpp
-        test/sa_key_unwrap_common.h
-        test/sa_key_unwrap_aes_cbc.cpp
-        test/sa_key_unwrap_aes_ctr.cpp
-        test/sa_key_unwrap_aes_ecb.cpp
-        test/sa_key_unwrap_aes_gcm.cpp
-        test/sa_key_unwrap_chacha20.cpp
-        test/sa_key_unwrap_chacha20_poly1305.cpp
-        test/sa_key_unwrap_ec.cpp
-        test/sa_key_unwrap_rsa.cpp
-        test/sa_crypto_cipher_multiple_thread.cpp
-        test/sa_provider_asym_cipher.cpp
-        test/sa_process_common_encryption.cpp
-        test/sa_process_common_encryption.h
-        test/sa_provider_cipher.cpp
-        test/sa_provider_common.cpp
-        test/sa_provider_common.h
-        test/sa_provider_kdf.cpp
-        test/sa_provider_keyexch.cpp
-        test/sa_provider_mac.cpp
-        test/sa_provider_pkcs7.cpp
-        test/sa_provider_signature.cpp
-        test/sa_svp_buffer_alloc.cpp
-        test/sa_svp_buffer_check.cpp
-        test/sa_svp_buffer_copy.cpp
-        test/sa_svp_buffer_create.cpp
-        test/sa_svp_buffer_release.cpp
-        test/sa_svp_buffer_write.cpp
-        test/sa_svp_key_check.cpp
-        test/sa_svp_common.cpp
-        test/sa_svp_common.h)
+if (BUILD_TESTS)
+    # Google test
+    add_executable(saclienttest
+            test/client_test_helpers.cpp
+            test/client_test_helpers.h
+            test/environment.cpp
+            test/sa_client_thread_test.cpp
+            test/sa_crypto_cipher_common.h
+            test/sa_crypto_cipher_common.cpp
+            test/sa_crypto_cipher_init.cpp
+            test/sa_crypto_cipher_init_aes_cbc.cpp
+            test/sa_crypto_cipher_init_aes_cbc_pkcs7.cpp
+            test/sa_crypto_cipher_init_aes_ctr.cpp
+            test/sa_crypto_cipher_init_aes_ecb.cpp
+            test/sa_crypto_cipher_init_aes_ecb_pkcs7.cpp
+            test/sa_crypto_cipher_init_aes_gcm.cpp
+            test/sa_crypto_cipher_init_ec_elgamal.cpp
+            test/sa_crypto_cipher_init_chacha20.cpp
+            test/sa_crypto_cipher_init_chacha20_poly1305.cpp
+            test/sa_crypto_cipher_init_rsa_oaep.cpp
+            test/sa_crypto_cipher_init_rsa_pkcs1v15.cpp
+            test/sa_crypto_cipher_process.cpp
+            test/sa_crypto_cipher_process_aes_cbc.cpp
+            test/sa_crypto_cipher_process_aes_cbc_pkcs7.cpp
+            test/sa_crypto_cipher_process_aes_ctr.cpp
+            test/sa_crypto_cipher_process_aes_ecb.cpp
+            test/sa_crypto_cipher_process_aes_ecb_pkcs7.cpp
+            test/sa_crypto_cipher_process_aes_gcm.cpp
+            test/sa_crypto_cipher_process_chacha20.cpp
+            test/sa_crypto_cipher_process_chacha20_poly1305.cpp
+            test/sa_crypto_cipher_process_ec_elgamal.cpp
+            test/sa_crypto_cipher_process_last.cpp
+            test/sa_crypto_cipher_process_last_aes_cbc.cpp
+            test/sa_crypto_cipher_process_last_aes_cbc_pkcs7.cpp
+            test/sa_crypto_cipher_process_last_aes_ctr.cpp
+            test/sa_crypto_cipher_process_last_aes_ecb.cpp
+            test/sa_crypto_cipher_process_last_aes_ecb_pkcs7.cpp
+            test/sa_crypto_cipher_process_last_aes_gcm.cpp
+            test/sa_crypto_cipher_process_last_chacha20_poly1305.cpp
+            test/sa_crypto_cipher_process_last_ec_elgamal.cpp
+            test/sa_crypto_cipher_process_last_rsa_oaep.cpp
+            test/sa_crypto_cipher_process_last_rsa_pkcs1v15.cpp
+            test/sa_crypto_cipher_process_rsa_oaep.cpp
+            test/sa_crypto_cipher_process_rsa_pkcs1v15.cpp
+            test/sa_crypto_cipher_release.cpp
+            test/sa_crypto_cipher_update_iv.cpp
+            test/sa_crypto_cipher_update_iv_aes_cbc.cpp
+            test/sa_crypto_cipher_update_iv_aes_cbc_pkcs7.cpp
+            test/sa_crypto_cipher_update_iv_aes_ctr.cpp
+            test/sa_crypto_cipher_update_iv_aes_ecb.cpp
+            test/sa_crypto_cipher_update_iv_aes_ecb_pkcs7.cpp
+            test/sa_crypto_cipher_update_iv_aes_gcm.cpp
+            test/sa_crypto_cipher_update_iv_chacha20.cpp
+            test/sa_crypto_cipher_update_iv_chacha20_poly1305.cpp
+            test/sa_crypto_cipher_update_iv_ec_elgamal.cpp
+            test/sa_crypto_cipher_update_iv_rsa_oaep.cpp
+            test/sa_crypto_cipher_update_iv_rsa_pkcs1v15.cpp
+            test/sa_crypto_mac_common.cpp
+            test/sa_crypto_mac_common.h
+            test/sa_crypto_mac_compute.cpp
+            test/sa_crypto_mac_init.cpp
+            test/sa_crypto_mac_process.cpp
+            test/sa_crypto_mac_process_key.cpp
+            test/sa_crypto_mac_release.cpp
+            test/sa_crypto_random.cpp
+            test/sa_crypto_sign.cpp
+            test/sa_crypto_sign_common.cpp
+            test/sa_crypto_sign_common.h
+            test/sa_crypto_sign_ec_ecdsa.cpp
+            test/sa_crypto_sign_ec_eddsa.cpp
+            test/sa_crypto_sign_rsa_pkcs1v15.cpp
+            test/sa_crypto_sign_rsa_pss.cpp
+            test/sa_engine_cipher.cpp
+            test/sa_engine_common.cpp
+            test/sa_engine_common.h
+            test/sa_engine_pkcs7.cpp
+            test/sa_engine_pkey_decrypt.cpp
+            test/sa_engine_pkey_derive.cpp
+            test/sa_engine_pkey_mac.cpp
+            test/sa_engine_pkey_sign.cpp
+            test/sa_get_device_id.cpp
+            test/sa_get_name.cpp
+            test/sa_get_ta_uuid.cpp
+            test/sa_get_version.cpp
+            test/sa_key_common.cpp
+            test/sa_key_common.h
+            test/sa_key_derive.cpp
+            test/sa_key_derive_ansi_x963.cpp
+            test/sa_key_derive_cmac.cpp
+            test/sa_key_derive_common.cpp
+            test/sa_key_derive_common.h
+            test/sa_key_derive_concat.cpp
+            test/sa_key_derive_hkdf.cpp
+            test/sa_key_derive_netflix.cpp
+            test/sa_key_derive_common_root_key_ladder.cpp
+            test/sa_key_derive_root_key_ladder.cpp
+            test/sa_key_digest.cpp
+            test/sa_key_exchange.cpp
+            test/sa_key_exchange_common.cpp
+            test/sa_key_exchange_common.h
+            test/sa_key_exchange_dh.cpp
+            test/sa_key_exchange_ecdh.cpp
+            test/sa_key_exchange_netflix.cpp
+            test/sa_key_export.cpp
+            test/sa_key_generate.cpp
+            test/sa_key_generate_dh.cpp
+            test/sa_key_generate_ec.cpp
+            test/sa_key_generate_rsa.cpp
+            test/sa_key_generate_symmetric.cpp
+            test/sa_key_get_public.cpp
+            test/sa_key_get_public_dh.cpp
+            test/sa_key_get_public_ec.cpp
+            test/sa_key_get_public_rsa.cpp
+            test/sa_key_get_public_symmetric.cpp
+            test/sa_key_header.cpp
+            test/sa_key_import.cpp
+            test/sa_key_import_common.cpp
+            test/sa_key_import_common.h
+            test/sa_key_import_ec_private_bytes.cpp
+            test/sa_key_import_exported.cpp
+            test/sa_key_import_rsa_private_key_info.cpp
+            test/sa_key_import_soc.cpp
+            test/sa_key_import_symmetric_bytes.cpp
+            test/sa_key_import_typej.cpp
+            test/sa_key_release.cpp
+            test/sa_key_unwrap.cpp
+            test/sa_key_unwrap_common.cpp
+            test/sa_key_unwrap_common.h
+            test/sa_key_unwrap_aes_cbc.cpp
+            test/sa_key_unwrap_aes_ctr.cpp
+            test/sa_key_unwrap_aes_ecb.cpp
+            test/sa_key_unwrap_aes_gcm.cpp
+            test/sa_key_unwrap_chacha20.cpp
+            test/sa_key_unwrap_chacha20_poly1305.cpp
+            test/sa_key_unwrap_ec.cpp
+            test/sa_key_unwrap_rsa.cpp
+            test/sa_crypto_cipher_multiple_thread.cpp
+            test/sa_provider_asym_cipher.cpp
+            test/sa_process_common_encryption.cpp
+            test/sa_process_common_encryption.h
+            test/sa_provider_cipher.cpp
+            test/sa_provider_common.cpp
+            test/sa_provider_common.h
+            test/sa_provider_kdf.cpp
+            test/sa_provider_keyexch.cpp
+            test/sa_provider_mac.cpp
+            test/sa_provider_pkcs7.cpp
+            test/sa_provider_signature.cpp
+            test/sa_svp_buffer_alloc.cpp
+            test/sa_svp_buffer_check.cpp
+            test/sa_svp_buffer_copy.cpp
+            test/sa_svp_buffer_create.cpp
+            test/sa_svp_buffer_release.cpp
+            test/sa_svp_buffer_write.cpp
+            test/sa_svp_key_check.cpp
+            test/sa_svp_common.cpp
+            test/sa_svp_common.h)
 
-target_compile_options(saclienttest PRIVATE -Werror -Wall -Wextra -Wno-type-limits -Wno-unused-parameter
-        -Wno-deprecated-declarations)
+    target_compile_options(saclienttest PRIVATE -Werror -Wall -Wextra -Wno-type-limits -Wno-unused-parameter
+            -Wno-deprecated-declarations)
 
-target_include_directories(saclienttest
-        PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../util/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        ${OPENSSL_INCLUDE_DIR}
-        )
-
-if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    # using Clang
     target_include_directories(saclienttest
             PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../util/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+            ${OPENSSL_INCLUDE_DIR}
             )
-endif ()
 
-target_link_libraries(saclienttest
-        PRIVATE
-        gtest_main
-        gmock_main
-        saclient
-        util
-        ${OPENSSL_CRYPTO_LIBRARY}
-        )
+    if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        # using Clang
+        target_include_directories(saclienttest
+                PRIVATE
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+                )
+    endif ()
 
-if (COVERAGE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(saclienttest
             PRIVATE
-            gcov
+            gtest_main
+            gmock_main
+            saclient
+            util
+            ${OPENSSL_CRYPTO_LIBRARY}
             )
+
+    if (COVERAGE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(saclienttest
+                PRIVATE
+                gcov
+                )
+    endif ()
+
+    target_clangformat_setup(saclienttest)
+
+    add_custom_command(
+            TARGET saclienttest POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
+            ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
+
+    gtest_discover_tests(saclienttest)
 endif ()
 
-target_clangformat_setup(saclienttest)
-
-add_custom_command(
-        TARGET saclienttest POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
-        ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
-
-gtest_discover_tests(saclienttest)
-
 # Doxygen
-option(BUILD_DOC "Build documentation" ON)
 if (BUILD_DOC)
     find_package(Doxygen)
     if (DOXYGEN_FOUND)

--- a/reference/src/taimpl/CMakeLists.txt
+++ b/reference/src/taimpl/CMakeLists.txt
@@ -206,48 +206,50 @@ target_compile_options(taimpl PRIVATE -Werror -Wall -Wextra -Wno-unused-paramete
 
 target_clangformat_setup(taimpl)
 
-# Google test
-add_executable(taimpltest
-        test/environment.cpp
-        test/ta_test_helpers.cpp
-        test/json.cpp
-        test/object_store.cpp
-        test/rights.cpp
-        test/slots.cpp
-        test/ta_sa_init.cpp
-        test/ta_sa_svp_buffer_check.cpp
-        test/ta_sa_svp_buffer_copy.cpp
-        test/ta_sa_svp_buffer_write.cpp
-        test/ta_sa_svp_common.cpp
-        test/ta_sa_svp_crypto.cpp
-        test/ta_sa_svp_crypto.h
-        test/ta_sa_svp_key_check.cpp)
+if (BUILD_TESTS)
+    # Google test
+    add_executable(taimpltest
+            test/environment.cpp
+            test/ta_test_helpers.cpp
+            test/json.cpp
+            test/object_store.cpp
+            test/rights.cpp
+            test/slots.cpp
+            test/ta_sa_init.cpp
+            test/ta_sa_svp_buffer_check.cpp
+            test/ta_sa_svp_buffer_copy.cpp
+            test/ta_sa_svp_buffer_write.cpp
+            test/ta_sa_svp_common.cpp
+            test/ta_sa_svp_crypto.cpp
+            test/ta_sa_svp_crypto.h
+            test/ta_sa_svp_key_check.cpp)
 
-target_include_directories(taimpltest
-        PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../client/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../util/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/internal>
-        ${OPENSSL_INCLUDE_DIR}
-        )
+    target_include_directories(taimpltest
+            PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../client/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../util/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/internal>
+            ${OPENSSL_INCLUDE_DIR}
+            )
 
-target_compile_options(taimpltest PRIVATE -Werror -Wall -Wextra -Wno-unused-parameter)
+    target_compile_options(taimpltest PRIVATE -Werror -Wall -Wextra -Wno-unused-parameter)
 
-target_link_libraries(taimpltest
-        PRIVATE
-        gtest_main
-        gmock_main
-        taimpl
-        util
-        ${OPENSSL_CRYPTO_LIBRARY}
-        )
+    target_link_libraries(taimpltest
+            PRIVATE
+            gtest_main
+            gmock_main
+            taimpl
+            util
+            ${OPENSSL_CRYPTO_LIBRARY}
+            )
 
-target_clangformat_setup(taimpltest)
+    target_clangformat_setup(taimpltest)
 
-add_custom_command(
-        TARGET taimpltest POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
-        ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
+    add_custom_command(
+            TARGET taimpltest POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
+            ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
 
-gtest_discover_tests(taimpltest)
+    gtest_discover_tests(taimpltest)
+endif ()

--- a/reference/src/util/CMakeLists.txt
+++ b/reference/src/util/CMakeLists.txt
@@ -72,33 +72,35 @@ target_compile_options(util PRIVATE -Werror -Wall -Wextra -Wno-unused-parameter)
 
 target_clangformat_setup(util)
 
-# Google test
-add_executable(utiltest
-        test/pkcs12test.cpp
-        )
+if (BUILD_TESTS)
+    # Google test
+    add_executable(utiltest
+            test/pkcs12test.cpp
+            )
 
-target_include_directories(utiltest
-        PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        ${OPENSSL_INCLUDE_DIR}
-        )
+    target_include_directories(utiltest
+            PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            ${OPENSSL_INCLUDE_DIR}
+            )
 
-target_compile_options(utiltest PRIVATE -Werror -Wall -Wextra -Wno-unused-parameter)
+    target_compile_options(utiltest PRIVATE -Werror -Wall -Wextra -Wno-unused-parameter)
 
-target_link_libraries(utiltest
-        PRIVATE
-        gtest
-        gmock_main
-        util
-        ${OPENSSL_CRYPTO_LIBRARY}
-        )
+    target_link_libraries(utiltest
+            PRIVATE
+            gtest
+            gmock_main
+            util
+            ${OPENSSL_CRYPTO_LIBRARY}
+            )
 
-target_clangformat_setup(utiltest)
+    target_clangformat_setup(utiltest)
 
-add_custom_command(
-        TARGET utiltest POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
-        ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
+    add_custom_command(
+            TARGET utiltest POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/test/root_keystore.p12
+            ${CMAKE_CURRENT_BINARY_DIR}/root_keystore.p12)
 
-gtest_discover_tests(utiltest)
+    gtest_discover_tests(utiltest)
+endif ()


### PR DESCRIPTION
It defaults to TRUE since we want to ensure our unit tests build and do not bit rot. But for libraries that depend on libsaclient.so it doesn't make sense for them to have a gtest dependancy and then build ELF executables that they will never use.