### PR TITLE
Issue_119: Resolve OpenSSL 3.x.x unit test discrepancies.

### DIFF
--- a/reference/src/client/test/sa_crypto_cipher_process_rsa_pkcs1v15.cpp
+++ b/reference/src/client/test/sa_crypto_cipher_process_rsa_pkcs1v15.cpp
@@ -134,6 +134,9 @@ namespace {
         ASSERT_EQ(status, SA_STATUS_OK);
         ASSERT_NE(cipher, nullptr);
 
+        // Initializing PKCS#1 v1.5 input buffer with garbage padding.
+        std::fill(in.begin(), in.begin() + 4, 0xff);
+
         auto in_buffer = buffer_alloc(SA_BUFFER_TYPE_CLEAR, in);
         ASSERT_NE(in_buffer, nullptr);
         size_t bytes_to_process = in.size();


### PR DESCRIPTION
An empty array used to trigger the invalid pad error for PKCS#1 v1.5 initial padding.  This stopped causing an error in more recent versions of OpenSSL.  We forcefully create a bad pad to verify this codepath is working properly.