### PR TITLE
Update SecAPI version number to prepare for 3.4.0 release

### DIFF
--- a/reference/src/client/CMakeLists.txt
+++ b/reference/src/client/CMakeLists.txt
@@ -85,8 +85,8 @@ target_compile_options(saclient PRIVATE -Werror -Wall -Wextra -Wno-type-limits -
 
 set_target_properties(saclient PROPERTIES
         LINKER_LANGUAGE C
-        SO_VERSION 3.3
-        VERSION 3.3.0
+        SO_VERSION 3.4
+        VERSION 3.4.0
         )
 
 target_include_directories(saclient

--- a/reference/src/client/include/sa.h
+++ b/reference/src/client/include/sa.h
@@ -47,7 +47,7 @@
 /**
  * SecAPI specification minor version
  */
-#define SA_SPECIFICATION_MINOR 3
+#define SA_SPECIFICATION_MINOR 4
 
 /**
  * SecAPI specification revision


### PR DESCRIPTION
Didn't include sa.h in the earlier merge.