### PR TITLE
Fix AES ECB PKCS#7 padding issue

### DIFF
--- a/reference/src/client/test/sa_crypto_cipher_process.cpp
+++ b/reference/src/client/test/sa_crypto_cipher_process.cpp
@@ -105,18 +105,13 @@ namespace {
         ASSERT_EQ(bytes_to_process, required_length);
 
         // decrypt using SecApi
-        auto out_buffer = buffer_alloc(buffer_type, bytes_to_process);
+        auto out_buffer = buffer_alloc(buffer_type, encrypted.size());
         ASSERT_NE(out_buffer, nullptr);
 
-        bytes_to_process = checked_length;
+        bytes_to_process = encrypted.size();
         status = sa_crypto_cipher_process(out_buffer.get(), *cipher, in_buffer.get(), &bytes_to_process);
         ASSERT_EQ(status, SA_STATUS_OK);
-        if (pkcs7) {
-            ASSERT_EQ(bytes_to_process + AES_BLOCK_SIZE, clear.size());
-            clear.resize(bytes_to_process);
-        } else {
-            ASSERT_EQ(bytes_to_process, clear.size());
-        }
+        ASSERT_EQ(bytes_to_process, clear.size());
 
         // Verify the decryption.
         ASSERT_TRUE(verify_decrypt(out_buffer.get(), clear));


### PR DESCRIPTION
Fail to run test of  SaCryptoCipherDecryptTest, processNominalm , it uses wrong packet size when handles AES ECB with PKCS#7 padding.

in addition, I remove those redundant code when pkcs7 flag is true.