### PR TITLE
Issue 149: Task: Mitigate Global Confusion Opportunity

### DIFF
--- a/reference/src/taimpl/src/internal/ta.c
+++ b/reference/src/taimpl/src/internal/ta.c
@@ -1871,6 +1871,13 @@ sa_status ta_invoke_command_handler(
             break;
         }
 
+        // Verify params[0] is a valid memref input before copying the buffer.
+        if (CHECK_NOT_TA_PARAM_IN(param_types[0]) && CHECK_NOT_TA_PARAM_INOUT(param_types[0])) {
+            ERROR("Invalid param[0] type");
+            status = SA_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
         // Cache the command parameter to prevent Time-of-use Time-of-check errors.
         command_parameter = memory_secure_alloc(params[0].mem_ref_size);
         if (command_parameter == NULL) {


### PR DESCRIPTION
Command buffer always sent in params[0] as a memref.  Prevent opportunity to input params[0] as a value by checking param type before buffer copy. 

Should not be a security risk, as the param type is checked after the copy, before any processing on the buffer is done, but it could be an opportunity to cause a segfault. 