### PR TITLE
Issue 160: Fix invalid buffer type validation in sa_process_common_encryption

### DIFF
--- a/reference/src/clientimpl/src/sa_process_common_encryption.c
+++ b/reference/src/clientimpl/src/sa_process_common_encryption.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Comcast Cable Communications Management, LLC
+ * Copyright 2020-2026 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This was a bug introduced with the SVP disable flag.