### PR TITLE
Rsa only mode tls fixes

### DIFF
--- a/reference/src/clientimpl/src/sa_crypto_cipher_process.c
+++ b/reference/src/clientimpl/src/sa_crypto_cipher_process.c
@@ -159,7 +159,6 @@ sa_status sa_crypto_cipher_process(
 #endif // ENABLE_SVP
 
         *bytes_to_process = cipher_process->bytes_to_process;
-	ERROR("bytes_to_process = %d\n", cipher_process->bytes_to_process);
     } while (false);
 
     RELEASE_COMMAND(cipher_process);

--- a/reference/src/clientimpl/src/sa_process_common_encryption.c
+++ b/reference/src/clientimpl/src/sa_process_common_encryption.c
@@ -117,7 +117,7 @@ sa_status sa_process_common_encryption(
                 subsample_length_s[j].bytes_of_protected_data = samples[i].subsample_lengths[j].bytes_of_protected_data;
             }
 
-            CREATE_PARAM(param1, samples[i].subsample_lengths, param1_size);
+            CREATE_PARAM(param1, subsample_length_s, param1_size);
             uint32_t param1_type = TA_PARAM_IN;
             size_t param2_size;
             uint32_t param2_type;

--- a/reference/src/taimpl/src/internal/ta.c
+++ b/reference/src/taimpl/src/internal/ta.c
@@ -483,6 +483,7 @@ static sa_status ta_invoke_key_unwrap(
     sa_unwrap_parameters_chacha20_s parameters_chacha_20_s;
     sa_unwrap_parameters_chacha20_poly1305_s parameters_chacha_20_poly_1305_s;
     sa_unwrap_parameters_rsa_oaep_s parameters_rsa_oaep_s;
+    sa_unwrap_parameters_ec_elgamal_s parameters_ec_elgamal_s;
     sa_unwrap_parameters_aes_cbc parameters_aes_cbc;
     sa_unwrap_parameters_aes_ctr parameters_aes_ctr;
     sa_unwrap_parameters_aes_gcm parameters_aes_gcm;
@@ -608,8 +609,10 @@ static sa_status ta_invoke_key_unwrap(
                 return SA_STATUS_INVALID_PARAMETER;
             }
 
-            memcpy(&parameters_ec_elgamal, params[2].mem_ref, params[2].mem_ref_size);
-            algorithm_parameters = params[2].mem_ref;
+            memcpy(&parameters_ec_elgamal_s, params[2].mem_ref, params[2].mem_ref_size);
+            parameters_ec_elgamal.offset = parameters_ec_elgamal_s.offset;
+            parameters_ec_elgamal.key_length = parameters_ec_elgamal_s.key_length;
+            algorithm_parameters = &parameters_ec_elgamal;
             break;
 
         case SA_CIPHER_ALGORITHM_RSA_OAEP:
@@ -1826,7 +1829,7 @@ static sa_status ta_invoke_process_common_encryption(
     sa_sample sample;
     do {
         sample.subsample_count = process_common_encryption->subsample_count;
-        if (params[1].mem_ref_size != sizeof(sa_subsample_length) * sample.subsample_count) {
+        if (params[1].mem_ref_size != sizeof(sa_subsample_length_s) * sample.subsample_count) {
             ERROR("params[1].mem_ref_size is invalid");
             return SA_STATUS_INVALID_PARAMETER;
         }


### PR DESCRIPTION
New Features:
- Add sa_provider_set_rsa_only_mode() API for RSA-only provider mode
- Export sa_provider_init() for OSSL_PROVIDER_add_builtin() registration
- In RSA-only mode, only RSA keymgmt/signature exposed; EC/DH/ciphers/digests fall through to default provider
- Enables TLS mTLS: RSA cert signing via SecAPI3, ECDH key exchange via default provider

Bug Fixes:
- sa_crypto_cipher_process.c: Remove debug ERROR log from production code
- sa_process_common_encryption.c: Use local subsample_length_s array for param1
- ta.c: Fix EC-ElGamal unwrap parameter struct handling
- ta.c: Fix common encryption subsample_length size check"
